### PR TITLE
Include link to 10.5 release notes in the blogs about this release

### DIFF
--- a/website/blog/2020-06-23-deliver-faster-applications-with-wavemaker.md
+++ b/website/blog/2020-06-23-deliver-faster-applications-with-wavemaker.md
@@ -7,6 +7,8 @@ Performance is [key to the success](https://developers.google.com/web/fundamenta
 
 <!-- truncate -->
 
+> This feature is part of WaveMaker 10.5 release. [Checkout more details on whats included this release](learn/wavemaker-release-notes/v10-5-0). 
+
 As per the Google stats link shared above, BBC lost 10% of its users with each additional second the site took to load & Pinterest gained 15% users signup when the perceived load times were reduced to 40%. So, performance is one of the important factors to consider in app development. An app with good performance can help businesses in better signups, enhanced user engagement & result in improved sales conversions.
 
 ### Performance in WaveMaker

--- a/website/blog/2020-06-23-deliver-faster-applications-with-wavemaker.md
+++ b/website/blog/2020-06-23-deliver-faster-applications-with-wavemaker.md
@@ -3,27 +3,27 @@ title: "Deliver faster applications with WaveMaker!"
 author: Subodh Kumar
 ---
 
-Performance is [key to the success](https://developers.google.com/web/fundamentals/performance/why-performance-matters) of any application. Even though an app is feature-rich if it's not responsive to user actions it might lose its userbase. WaveMaker is a platform enables our users to develop web, mobile applications and we would like to enable theses apps to performance as well as possible. Towards this goal, with each release, WaveMaker introduces changes aiding in optimization to generated apps in terms of code, build outputs & serviing of the apps. The optimizations are made available to the customers out of the box. It requires minimal or no changes to be done by low code developers while building an app in WaveMaker, thus easing the process of building faster apps.
+Performance is [key to the success](https://developers.google.com/web/fundamentals/performance/why-performance-matters) of any application. Even though an app is feature-rich if it's not responsive to user actions it might lose its userbase. WaveMaker is a platform enables our users to develop web, mobile applications. We strive to enable top notch performance of these apps. Towards this goal, with each release, WaveMaker introduces changes aiding in optimization of generated apps in terms of code, build outputs & serving of the apps. The optimizations are made available to the customers out of the box. It requires minimal or no changes to be done by low code developers while building an app in WaveMaker, thus easing the process of building faster apps.
 
 <!-- truncate -->
 
 > This feature is part of WaveMaker 10.5 release. [Checkout more details on whats included this release](learn/wavemaker-release-notes/v10-5-0). 
 
-As per the Google stats link shared above, BBC lost 10% of its users with each additional second the site took to load & Pinterest gained 15% users signup when the perceived load times were reduced to 40%. So, performance is one of the important factors to consider in app development. An app with good performance can help businesses in better signups, enhanced user engagement & result in improved sales conversions.
+As per the Google stats link shared above, BBC lost 10% of its users with each additional second the site took to load & Pinterest gained 15% users signup when the perceived load times were reduced to 40%. So, performance is one of the important factors to consider in app development. An app with good performance can help businesses in better signups, enhanced user engagement & result in improved sales.
 
 ### Performance in WaveMaker
 
-WaveMaker is a low code platform that continuously works on performance optimizations so that it helps customers to quickly build & ship apps with great performance. WaveMaker adopts the best practices that are evolving in the world of web applications and bring those to its customers & applications.
+WaveMaker is a low code platform that continuously works on performance optimizations so that it helps customers to not only build quickly but deliver application that load fast. WaveMaker adopts the best practices that are evolving in the world of web applications and brings those to its customers & applications.
 
-When a user requests for an app, the speed with which it loads & becomes responsive is a testimony to its performance. The loading speed is a function of below-listed factors,
+When a user accesses an app, the speed with which it loads & becomes responsive is a testimony to its performance. Each page in the application infact needs multiple resources to be loaded. The loading speed is a function of below-listed factors,
 
-* Bundle Size
-* Network Quality
-* Number of Resource Requests
-* API/Service response quality
+* Size of the resources loaded by the page
+* Network Speed
+* Number of HTTP Resource Requests required to build the page
+* Time spend on the server in crafting the response
 * User perception of app readiness
 
-WaveMaker generates Angular code for the applications, thus has the flexibility to leverage Angular build tools to optimize the application for better load times. Besides, if third party dependencies are required, modular libraries are preferred. WaveMaker component library of 100+ rich widgets. Still, the application build is only composed of components used. Below is the summary of optimizations that are delivered over past releases,
+WaveMaker generates Angular code for the applications. Thus has the flexibility to leverage Angular build tools to optimize the application for better load times. Besides, if third party dependencies are required, modular libraries are preferred. WaveMaker component library of 100+ rich widgets. Still, the application build is only composed of components used. Below is the summary of optimizations that are delivered over past releases,
 
 * Treeshaking/Dead Code Elimination, with the help of Angular Production Build & modular component library
 * Lazy Loading of Routes & Components, so that user is served with just the required code as they navigate pages of the app
@@ -32,6 +32,7 @@ WaveMaker generates Angular code for the applications, thus has the flexibility 
 With the current release i.e., version 10.5, WaveMaker team is pleased to announce support for deployment of frontend artifacts onto a Content Delivery Network, which can help in reducing the download time of static resources by ~30%.
 
 ### Content Delivery Network
+
 A Content Delivery Network(CDN) is a set of the geographically distributed servers which together enable fast, reliable & secure delivery of internet content including HTML, Javascript, Stylesheets, Images, etc., 
 
 With CDN, the content is served from the CDN-edge server closest to the user location helping in faster load times. With caching & other optimizations CDN also reduces the amount of data origin servers must provide, thus reducing hosting costs. With its distributed nature CDN can ensure better availability and can handle failures better than any origin servers. With all these benefits CDN ensures consistent user experience for an app across the geographical locations. 
@@ -66,6 +67,4 @@ Below are the stats from WaveMaker testing with CDN integration comparing the do
 | WaveKart    |                   ~29%| 
 | [SalesVision](https://www.wavemaker.com/showcase/docs/salesVision) |                   ~30%| 
 
-As stated, improving performance is a continuous endeavor for WaveMaker & more optimizations will be delivered to the customers with each release. It will enable our customers to build & deliver faster apps for their users leading to successful collaboration.
-
-Stay tuned for more.  Also please share your thoughts or feedback on the optimizations achieved or other approaches to improve the performance of WaveMaker apps to info@wavemaker.com
+As stated, improving performance is a continuous endeavor for WaveMaker & more optimizations will be delivered to the customers with each release. So, stay tuned for more.  Also please share your thoughts or feedback on the optimizations achieved or other approaches to improve the performance of WaveMaker apps to info@wavemaker.com

--- a/website/blog/2020-06-23-deliver-faster-applications-with-wavemaker.md
+++ b/website/blog/2020-06-23-deliver-faster-applications-with-wavemaker.md
@@ -7,7 +7,7 @@ Performance is [key to the success](https://developers.google.com/web/fundamenta
 
 <!-- truncate -->
 
-> This feature is part of WaveMaker 10.5 release. [Checkout more details on whats included this release](learn/wavemaker-release-notes/v10-5-0). 
+> This feature is part of WaveMaker 10.5 release. [Checkout more details on what is included this release](learn/wavemaker-release-notes/v10-5-0). 
 
 As per the Google stats link shared above, BBC lost 10% of its users with each additional second the site took to load & Pinterest gained 15% users signup when the perceived load times were reduced to 40%. So, performance is one of the important factors to consider in app development. An app with good performance can help businesses in better signups, enhanced user engagement & result in improved sales.
 

--- a/website/blog/2020-06-24-wavemaker-mobile-filepicker.md
+++ b/website/blog/2020-06-24-wavemaker-mobile-filepicker.md
@@ -26,4 +26,4 @@ Like always, with WaveMaker product updates, we also migrate applications that a
 
  1. In iOS, selection of multiple videos from local Photo Library is not supported.
  
- > This feature is part of WaveMaker 10.5 release. [Checkout more details on whats included this release](learn/wavemaker-release-notes/v10-5-0).
+ > This feature is part of WaveMaker 10.5 release. [Checkout more details on what is included in this release](learn/wavemaker-release-notes/v10-5-0).

--- a/website/blog/2020-06-24-wavemaker-mobile-filepicker.md
+++ b/website/blog/2020-06-24-wavemaker-mobile-filepicker.md
@@ -25,3 +25,5 @@ Like always, with WaveMaker product updates, we also migrate applications that a
 ## Known Issues
 
  1. In iOS, selection of multiple videos from local Photo Library is not supported.
+ 
+ > This feature is part of WaveMaker 10.5 release. [Checkout more details on whats included this release](learn/wavemaker-release-notes/v10-5-0).

--- a/website/blog/2020-06-30-run-zalenium-tests-on-kubernetes-blog.md
+++ b/website/blog/2020-06-30-run-zalenium-tests-on-kubernetes-blog.md
@@ -4,10 +4,10 @@ author: Tejaswi Maryala, Harish Vanama
 keywords: zalenium, selenium-grid, kubernetes, frequent-releases
 ---
 
-Typically product releases involve testing of several micro services, API’s and User interface, functionality etc. WaveMaker platform is composed of several such services, and functional testing can be only done by building apps using visual drag-n-drop studio. To ensure the best product quality for releases, our QA process involves building automation tests for APIs as well as UI functionality using Selenium.  
-        
-        * UI Tests based on Selenium
-        * API Tests based on RestTemplate 
+WaveMaker product team is able to make [weekly patch releases and, feature packed releases](/learn/wavemaker-release-notes) every alternate months. Typically product releases involve testing of several micro services, API’s and User interface, functionality etc. WaveMaker platform is composed of several such services, and functional testing can be only done by building apps using visual drag-n-drop studio. To ensure the best product quality for releases, our QA process involves building automation tests for APIs as well as UI functionality using Selenium.  
+
+1. UI Tests based on Selenium
+2. API Tests based on RestTemplate 
 
 We have multiple environments i.e., Development, Staging and Production for WMO and several on-premise WME environment setups for enterprise customer releases. Our development team uses feature branches and when they merge these branches onto the master branch, we have to make sure all the existing automation tests pass. On a regular basis when each feature team performs a merge, we run a full set of automation tests at their beck and call.
 
@@ -43,8 +43,8 @@ As the test repo keeps updated frequently by the QA team with new automation tes
 
 Once k8s Job has started, a Pod will be created to execute commands in the k8s spec file given below
 
-    * Maven command to execute tests
-    * Upload test results to s3.
+* Maven command to execute tests
+* Upload test results to s3.
 
 On completion of above commands, respective Job status will be changed to complete. 
 
@@ -66,11 +66,4 @@ Sanity Tests Execution|55%
 Regression Tests Execution|60% (10 hours -> 4 hours)
 Sanity and Regression as parallel Jobs|60%
 
-
-
-
-
-
-
-
-
+> Checkout whats in our latest release [WaveMaker 10.5 here](/learn/wavemaker-release-notes/v10-5-0).

--- a/website/blog/2020-06-30-run-zalenium-tests-on-kubernetes-blog.md
+++ b/website/blog/2020-06-30-run-zalenium-tests-on-kubernetes-blog.md
@@ -66,4 +66,4 @@ Sanity Tests Execution|55%
 Regression Tests Execution|60% (10 hours -> 4 hours)
 Sanity and Regression as parallel Jobs|60%
 
-> Checkout whats in our latest release [WaveMaker 10.5 here](/learn/wavemaker-release-notes/v10-5-0).
+> Checkout what is in our latest release [WaveMaker 10.5 here](/learn/wavemaker-release-notes/v10-5-0).

--- a/website/blog/2020-07-01-wavemaker-openapi-postgrest-support.md
+++ b/website/blog/2020-07-01-wavemaker-openapi-postgrest-support.md
@@ -121,6 +121,8 @@ If you have a look at the request parameters for the POST API, you can see that 
 
 Since we did not have this kind of parsing logic in 10.4, we were unable to extract the form fields on dragging a Form widget for **Employee** Entity.
 
+> This feature is part of WaveMaker 10.5 release. [Checkout more details on whats included this release](learn/wavemaker-release-notes/v10-5-0).
+
 ## Conclusion
 
 The OpenAPI support in WaveMaker has been around for few months now and with this release we are making this more robust. Our target is to be able to import API from varied sources so that our users can quickly build out web, mobile applications. We would love to hear from you, if you have tried this feature out. Write to us at info@wavemaker.com. 

--- a/website/blog/2020-07-01-wavemaker-openapi-postgrest-support.md
+++ b/website/blog/2020-07-01-wavemaker-openapi-postgrest-support.md
@@ -121,7 +121,7 @@ If you have a look at the request parameters for the POST API, you can see that 
 
 Since we did not have this kind of parsing logic in 10.4, we were unable to extract the form fields on dragging a Form widget for **Employee** Entity.
 
-> This feature is part of WaveMaker 10.5 release. [Checkout more details on whats included this release](learn/wavemaker-release-notes/v10-5-0).
+> This feature is part of WaveMaker 10.5 release. [Checkout more details on what is included in this release](learn/wavemaker-release-notes/v10-5-0).
 
 ## Conclusion
 


### PR DESCRIPTION
Included link to 10.5 releases on the blogs detailing the changes inside this release

So the change looks like this in each of the blogs:

![image](https://user-images.githubusercontent.com/57487155/86253101-b0fab200-bbd1-11ea-80e1-f0697938cd88.png)
