### PR TITLE
Update deployment-using-docker-compose.md

### DIFF
--- a/learn/app-development/deployment/deployment-using-docker-compose.md
+++ b/learn/app-development/deployment/deployment-using-docker-compose.md
@@ -77,7 +77,7 @@ server {
    location / {
        proxy_pass http://webapp_wm;
    }
-
+   underscores_in_headers on;
    proxy_ssl_server_name on;
    proxy_set_header X-Real-IP  $remote_addr;
    proxy_set_header X-SSL-Request 1;


### PR DESCRIPTION
Added syntax "underscores_in_headers on" for nginx to allow the use of underscores in client request header fields.

Issue: https://discourse.wavemaker.com/t/wavemaker-exposed-api-rest-services-are-not-acessible-with-nginx-uri/524
Solution: http://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers