### PR TITLE
Updated-doc-integrating-junit-tests-for-wavemaker-application

### DIFF
--- a/learn/how-tos/integrating-junit-tests-for-wavemaker-application.md
+++ b/learn/how-tos/integrating-junit-tests-for-wavemaker-application.md
@@ -90,7 +90,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(loader = GenericXmlWebContextLoader.class,
-        locations = "classpath:project-springapp-test.xml")
+        locations = "classpath:project-springapp-test.xml", initializers = com.wavemaker.runtime.security.DefaultBootStrapPropertySourceInitializer.class)
 @WebAppConfiguration
 public abstract class BaseTest {
 


### PR DESCRIPTION
Added DefaultBootStrapPropertySourceInitializer class as context initializer in BaseTest.java class ContextConfiguration annotation. As mentioned in the Discourse link to solve the issue seen in Junit tests. 
https://discourse.wavemaker.com/t/junit-tests-issue/883