### PR TITLE
Included WaveMaker supported version in Devtool documentation

### DIFF
--- a/learn/app-development/dev-integration/chrome-developer-tool.md
+++ b/learn/app-development/dev-integration/chrome-developer-tool.md
@@ -5,7 +5,12 @@ sidebar_label: "Chrome Extension: Devtool"
 ---
 ---
 
-**WaveMaker Devtool** is a Google Chrome extension, an addition to the existing Google Chrome developer tools that allow you to debug and monitor WaveMaker applications in preview mode. Accessible via the **Inspect** option. WaveMaker DevTool supports WaveMaker v10.14.0 and later.
+**WaveMaker Devtool** is a Google Chrome extension, an addition to the existing Google Chrome developer tools that allow you to debug and monitor WaveMaker applications in preview mode. Accessible via the **Inspect** option. 
+
+
+:::note
+WaveMaker Devtool supports [WaveMaker 10.14.0](/learn/wavemaker-release-notes/v10-14-0) and later.
+:::
 
 ## Devtool Installation
 

--- a/learn/app-development/dev-integration/chrome-developer-tool.md
+++ b/learn/app-development/dev-integration/chrome-developer-tool.md
@@ -5,7 +5,7 @@ sidebar_label: "Chrome Extension: Devtool"
 ---
 ---
 
-**WaveMaker Devtool** is a Google Chrome extension, an addition to the existing Google Chrome developer tools that allow you to debug and monitor WaveMaker applications in preview mode. Accessible via the **Inspect** option.
+**WaveMaker Devtool** is a Google Chrome extension, an addition to the existing Google Chrome developer tools that allow you to debug and monitor WaveMaker applications in preview mode. Accessible via the **Inspect** option. WaveMaker DevTool supports WaveMaker v10.14.0 and later.
 
 ## Devtool Installation
 

--- a/learn/wavemaker-release-notes/v10-14-0.md
+++ b/learn/wavemaker-release-notes/v10-14-0.md
@@ -8,6 +8,10 @@ sidebar_label: "Release v10.14.0"
 ## New Features
 ---
 
+### [Google Chrome Extension: WaveMaker Devtool](https://chrome.google.com/webstore/detail/wavemaker-devtool/niakeolhkmomhekokhdbfiaebkganjnk)
+
+**WaveMaker Devtool** is a developer tool avaiable as a Google Chrome extension, specifically developed to debug and monitor WaveMaker applications in preview mode. For more information, see [WaveMaker Devtool](/learn/app-development/dev-integration/chrome-developer-tool).
+
 ### SSL for Deployed Apps
 
 Introducing SSL for Deployed Apps to [Demo Cloud](/learn/app-development/deployment/pipelines-phases#deployment-environment), allowing you to access apps with the secure protocol HTTPS. To support this, we made changes to the App URL pattern. Below are the changes.


### PR DESCRIPTION
Included information in devtool doc that devtool is supported from WaveMaker v10.14.0 and later