### PR TITLE
Updating beta to 11 

### DIFF
--- a/learn/app-development/wavemaker-overview/faqs-11.md
+++ b/learn/app-development/wavemaker-overview/faqs-11.md
@@ -1,7 +1,7 @@
 ---
-title: "FAQs of WaveMaker 11 Beta"
+title: "FAQs of WaveMaker 11"
 id: ""
-sidebar_label: "FAQs 11 Beta"
+sidebar_label: "FAQs 11"
 ---
 ---
 

--- a/learn/app-development/wavemaker-overview/wavemaker-11-beta.md
+++ b/learn/app-development/wavemaker-overview/wavemaker-11-beta.md
@@ -1,9 +1,13 @@
 ---
 title: "WaveMaker 11 Beta"
 id: ""
-sidebar_label: "WaveMaker 11 Beta"
+sidebar_label: "WaveMaker 11"
 ---
 ---
+
+:::note
+This document contains information about WaveMaker 11 Beta. We provided fixes and improvements to the features since we released 11 Beta—now outdated. Follow our [release notes page](/learn/wavemaker-release-notes) for up-to-date information. Learn more about [WaveMaker 11.1](/learn/wavemaker-release-notes/v11-1-0) (latest).
+:::
 
 We are back with a new release, and we can't wait to share all the great features and updates waiting for you in WaveMaker 11 beta.
 

--- a/learn/how-tos/upgrade-guide-wavemaker-10-to-11.md
+++ b/learn/how-tos/upgrade-guide-wavemaker-10-to-11.md
@@ -1,7 +1,7 @@
 ---
 title: "Updating an App from WaveMaker 10 WaveMaker 11"
 id: ""
-sidebar_label: "Upgrade Guide 11 beta"
+sidebar_label: "Upgrade Guide 11"
 ---
 ---
 

--- a/learn/wavemaker-release-notes.md
+++ b/learn/wavemaker-release-notes.md
@@ -21,7 +21,7 @@ Follow our [team blog](/learn/blog) to learn product updates from the engineers 
 
 |Named Version|What's in it| Release Date|
 |---|---|---|
-|[WaveMaker 11 GA](/learn/wavemaker-release-notes/v11-1-0) <p style="color:red;">*latest*</p>  |Feature-packed with Angular 12 update, React Native improvements, Azure Repos, MTLS for REST APIs, and more.| 29 August 2022 |
+|[WaveMaker 11.1](/learn/wavemaker-release-notes/v11-1-0) <p style="color:red;">*latest*</p>  |Feature-packed with Angular 12 update, React Native improvements, Azure Repos, MTLS for REST APIs, and more.| 29 August 2022 |
 |[WaveMaker 11.0.3 Beta](/learn/wavemaker-release-notes/v11-0-3) |Issues related to Content Security Policy, Chips widget and Teams Portal configuration.| 25 July 2022 |
 |[WaveMaker 11.0.2 Beta](/learn/wavemaker-release-notes/v11-0-2) |Issues related to importing Web Services with OAuth 2.0 and previewing applications with Prefabs and more such bug fixes are addressed. | 11 July 2022 |
 |[WaveMaker 11 Beta (11.0.1)](/learn/wavemaker-release-notes/v11-0-1)|Includes new features like React Native, Multi-version Studio, API composer toolkit, API Mock Server extension, pagination for imported APIs, Java 11 and SAML library updates. [Read more.](/learn/app-development/wavemaker-overview/wavemaker-11-beta) | 06 June 2022 |

--- a/learn/wavemaker-release-notes/v11-1-0.md
+++ b/learn/wavemaker-release-notes/v11-1-0.md
@@ -1,18 +1,18 @@
 ---
-title: "WaveMaker 11 GA - Release date: 29 August 2022"
+title: "WaveMaker 11.1 - Release date: 29 August 2022"
 id: ""
-sidebar_label: "v11 GA - latest"
+sidebar_label: "v11.1 - latest"
 ---
 New features, such as Angular 12 update, React Native improvements, and a few bug fixes, are included.
 
-## New Features
+## New Features and Improvements
 ---
 
 ### React Native Studio
 
 [React Native](/learn/react-native/react-native) provides new and improved canvas experience, along with the following enhancements.
 
-- React Native Studio now supports Plugins. For example, Camera, Geolocation, QR code, and more.
+- React Native Studio supports Plugins. For example, Camera, Geolocation, Barcode, and more as a standard. Plus, plugins supported by [Expo](https://docs.expo.dev/versions/v45.0.0/sdk/accelerometer/).
 - Introduced [Layout Widget](/learn/app-development/widgets/container/layout)
 - Introduced [Flex Layout Widget](/learn/app-development/widgets/container/flex-layout)
 - Supporting [Form Validation](/learn/app-development/widgets/datalive/field-validator)

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1327,7 +1327,7 @@
         "ids": 
           [
           "app-development/wavemaker-overview/wavemaker-11-beta",
-          "app-development/wavemaker-overview/faqs-11-beta",
+          "app-development/wavemaker-overview/faqs-11",
           "how-tos/upgrade-guide-wavemaker-10-to-11" 
           ]
         }


### PR DESCRIPTION
Release notes page sidebar updated:
1. WaveMaker 11 beta to WaveMaker 11. Plus, I added a note that it contains outdated info. 
2. Upgrade guide 11.
3. FAQs file name updated too.
