### PR TITLE
Updated Redirect URLs for security providers

### DIFF
--- a/learn/how-tos/implement-openid-auth0-provider.md
+++ b/learn/how-tos/implement-openid-auth0-provider.md
@@ -47,6 +47,9 @@ Below are the steps to create an application in Auth0 Developer.
 
 :::note
 - **Redirect URL:** Redirect endpoint is the URL to which the client receives the response
+- Redirect URL is pre-populated by WaveMaker and is not editable. You need to copy this link and use it to as the callback URL in Provider app settings page when you register the app.
+- If the application is deployed outside of WaveMaker then the redirect URL for the deployed applications will be in the below format. 
+  **"https://<domain_name>/<app_name>/oauth2/code/{providerid}"**.
 :::
 
 [![](/learn/assets/auth0-redirectURL.png)](/learn/assets/auth0-redirectURL.png)

--- a/learn/how-tos/implement-openid-google-provider.md
+++ b/learn/how-tos/implement-openid-google-provider.md
@@ -82,6 +82,12 @@ Below are the steps to create an application in Google Console.
 [![](/learn/assets/wm_openid_gc16.png)](/learn/assets/wm_openid_gc16.png)
 [![](/learn/assets/wm_openid_gc17.png)](/learn/assets/wm_openid_gc17.png)
 
+:::note
+- **Redirect URL** is pre-populated by WaveMaker and is not editable. You need to copy this link and use it to as the callback URL in Provider app settings page when you register the app.
+- If the application is deployed outside of WaveMaker then the redirect URL for the deployed applications will be in the below format. 
+  **"https://<domain_name>/<app_name>/oauth2/code/{providerid}"**.
+:::
+
 2. Collect the **Client ID** and **Client Secret** by clicking **Download Json**.
 [![](/learn/assets/wm_openid_gc18.png)](/learn/assets/wm_openid_gc18.png)
 

--- a/learn/how-tos/implement-openid-okta-provider.md
+++ b/learn/how-tos/implement-openid-okta-provider.md
@@ -51,6 +51,9 @@ Below are the steps to create an application in Okta Developer.
 
 :::note
 - **Redirect URL:** Redirect endpoint is the URL to which the client receives the response
+- Redirect URL is pre-populated by WaveMaker and is not editable. You need to copy this link and use it to as the callback URL in Provider app settings page when you register the app.
+- If the application is deployed outside of WaveMaker then the redirect URL for the deployed applications will be in the below format. 
+  **"https://<domain_name>/<app_name>/oauth2/code/{providerid}"**.
 :::
 
 [![](/learn/assets/wm_openid_ok9.png)](/learn/assets/wm_openid_ok9.png)

--- a/learn/how-tos/sso-openid-azure-active-directory.md
+++ b/learn/how-tos/sso-openid-azure-active-directory.md
@@ -97,6 +97,9 @@ You'll need the the Endpoints from [OpenID Connect metadata document](#endpoints
 ### 2. Service Provider Information
 
 - **Redirect Url**: Go to the app [overview](#note-these-details) page in Azure AD, and enter this URL in the **Redirect URLs** section.
+- Redirect URL is pre-populated by WaveMaker and is not editable. You need to copy this link and use it to as the callback URL in Provider app settings page when you register the app.
+- If the application is deployed outside of WaveMaker then the redirect URL for the deployed applications will be in the below format. 
+  **"https://<domain_name>/<app_name>/oauth2/code/{providerid}"**.
 
 ### 3. Integration Information
 


### PR DESCRIPTION
Updated Redirect URLs for the below security providers:

1. openid-authO-provider.
2. openid-google-provider.
3. openid-okta-provider.
4. openid-azure-active-directory.